### PR TITLE
Update copyright holder in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Jonathan Fraine
+Copyright (c) 2024 Wikimedia Deutschland e.V.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Changed from  owner from original github repo to Wikimedia Deutschland e.V.